### PR TITLE
proc: Don't let Google Camera run in the background

### DIFF
--- a/fs/proc/base.c
+++ b/fs/proc/base.c
@@ -105,6 +105,20 @@
 
 #include "../../lib/kstrtox.h"
 
+struct task_kill_info {
+	struct task_struct *task;
+	struct work_struct work;
+};
+
+static void proc_kill_task(struct work_struct *work) {
+	struct task_kill_info *kinfo = container_of(work, typeof(*kinfo), work);
+	struct task_struct *task = kinfo->task;
+
+	send_sig(SIGKILL, task, 0);
+	put_task_struct(task);
+	kfree(kinfo);
+}
+
 /* NOTE:
  *	Implementing inode permission operations in /proc is almost
  *	certainly an error.  Permission checks need to happen during
@@ -1004,6 +1018,7 @@ static ssize_t oom_adj_read(struct file *file, char __user *buf, size_t count,
 static int __set_oom_adj(struct file *file, int oom_adj, bool legacy)
 {
 	struct mm_struct *mm = NULL;
+	char task_comm[TASK_COMM_LEN];
 	struct task_struct *task;
 	int err = 0;
 
@@ -1055,6 +1070,9 @@ static int __set_oom_adj(struct file *file, int oom_adj, bool legacy)
 		task->signal->oom_score_adj_min = (short)oom_adj;
 	trace_oom_score_adj_update(task);
 
+	if (oom_adj >= 700) 
+		strncpy(task_comm, task->comm, TASK_COMM_LEN);
+
 	if (mm) {
 		struct task_struct *p;
 
@@ -1081,6 +1099,19 @@ static int __set_oom_adj(struct file *file, int oom_adj, bool legacy)
 err_unlock:
 	mutex_unlock(&oom_adj_mutex);
 	put_task_struct(task);
+	if (!err && oom_adj >= 700) {
+		if (!strcmp(task_comm, "id.GoogleCamera")) {
+			struct task_kill_info *kinfo;
+
+			kinfo = kmalloc(sizeof(*kinfo), GFP_KERNEL);
+			if (kinfo) {
+				get_task_struct(task);
+				kinfo->task = task;
+				INIT_WORK(&kinfo->work, proc_kill_task);
+				schedule_work(&kinfo->work);
+			}
+		}
+	}
 	return err;
 }
 


### PR DESCRIPTION
Google Camera burns through CPU in background doing nothing useful.

It indefinitely causes Google Photos' CPU usage to go to 150% and increases the CPU utilization of some other system processes.

Kill it when it become backgrounded to prevent it from killing battery life.